### PR TITLE
remove duplicate postgres vector instance from ai-supply-chain-agent 

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Everything else in `helm/values.yaml` works with the chart defaults (images, PGV
 | `global.models.external-model.id` / `url` | Different MaaS model or endpoint (also drives `LLAMA_STACK_MODEL` / `LLAMA_STACK_OPENAI_MODEL` in the backend Deployment) |
 | `backend.env.EMBED_MODEL` | Different embedding model ID |
 | `backend.env.LLAMA_STACK_URL` | Release installed outside `supply-chain-dashboard` namespace (default URL is namespace-scoped) |
-| `pgvector.secret.*` | Non-demo database credentials |
+| `pgvector.secret.*` | Shared Postgres credentials for Llama Stack / backend (must match gen-sim Postgres password when `pgvector.enabled: false`) |
 | `llm-service.enabled` + `device` / per-model `device` | Local inference instead of MaaS |
 | `ingest.strategy` | `langchain` for PGVector ingest instead of default `llamastack` |
 | `general-simulation.api.llm.*` | Gen-sim OpenAI endpoint / model overrides (`apiKey` in secrets) |
@@ -290,9 +290,9 @@ make helm-status
 The umbrella chart in `helm/` deploys:
 - **Backend** — Flask API (port 5001), Route `supply-chain-dashboard-backend`
 - **Frontend** — React SPA served by nginx (port 8080), Route `supply-chain-dashboard-frontend`
-- **PGVector** — PostgreSQL + pgvector (subchart)
+- **Shared Postgres** — gen-sim Postgres (AGE + pgvector + PostGIS); optional standalone `pgvector` subchart for agent-only installs
 - **Llama Stack** — inference API (subchart); default provider is MaaS / external-model
-- **General Simulation** — subchart enabled by default (own Postgres + Neo4j + API; OpenAI LLM via secrets; not wired to MaaS). Live OpenSky CronJob is **off** by default.
+- **General Simulation** — subchart enabled by default (Postgres + Neo4j + API; OpenAI LLM via secrets; not wired to MaaS). Live OpenSky CronJob is **off** by default.
 - **Ingest Job** — optional post-install job (`ingest.enabled`) that loads the knowledge base
 - **Egress NetworkPolicy** — optional (`networkPolicy.egress.enabled`) for namespaces that default-deny outbound traffic
 

--- a/docs/WHAT_TO_EXPECT.md
+++ b/docs/WHAT_TO_EXPECT.md
@@ -15,7 +15,7 @@ A Helm install (`supply-chain-dashboard` in `./helm`) brings up the application 
 | **Backend** (`supply-chain-dashboard-backend`) | Flask API on port 5001 — impact simulation proxy, RAG chat, knowledge-base uploads, scenario create |
 | **Frontend** (`supply-chain-dashboard-frontend`) | React SPA on port 8080 — impact workspace (standalone Route) |
 | **General Simulation** (subchart, enabled by default) | Impact engine (API + Neo4j + Postgres) for scenarios, GeoJSON entities, and NL impact queries |
-| **PGVector** (subchart) | PostgreSQL with pgvector; used for LangChain ingest and default chat RAG when no vector store is selected |
+| **Shared Postgres** (gen-sim subchart) | PostgreSQL with AGE + pgvector + PostGIS; agent RAG and gen-sim share one instance (`pgvector.enabled: false` by default) |
 | **Llama Stack** (subchart) | LLM and vector-store APIs for chat and ingestion (default inference: MaaS / `external-model`) |
 | **LLM service** (subchart, **disabled** by default) | Optional in-cluster model serving; enable only for Option B (local CPU/GPU) |
 | **Ingest Job** (optional, `ingest.enabled`) | Post-install job that loads bundled risk documents (`ingest.strategy`: **`llamastack`** by default → Llama Stack vector stores; set `langchain` for PGVector) |
@@ -34,7 +34,7 @@ make oc-status
 oc get pods,route -n supply-chain-dashboard
 ```
 
-Wait until backend, frontend, pgvector, llamastack, and general-simulation pods are **Running** and the ingest job (if enabled) has **Completed**. First startup can take several minutes while Llama Stack becomes ready (and longer if you enable a local model).
+Wait until backend, frontend, llamastack, gen-sim Postgres, and general-simulation pods are **Running** and the ingest job (if enabled) has **Completed**. First startup can take several minutes while Llama Stack becomes ready (and longer if you enable a local model).
 
 ### Map / OpenSky data (important)
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: supply-chain-agent
-description: AI Supply Chain Agent — demo dashboard with pgvector and Llama Stack
+description: AI Supply Chain Agent — demo dashboard with shared Postgres (pgvector) and Llama Stack
 type: application
 version: 0.2.0
 appVersion: "0.1.0"

--- a/helm/README.md
+++ b/helm/README.md
@@ -4,10 +4,10 @@ Umbrella chart for the AI Supply Chain Agent quickstart. It deploys the applicat
 
 ## What it deploys
 
-- **pgvector** — PostgreSQL with the pgvector extension (agent RAG; kept even when gen-sim is enabled)
+- **Shared Postgres** — gen-sim’s Postgres (AGE + pgvector + PostGIS) stores agent RAG and gen-sim data; optional standalone `pgvector` subchart only for agent-only installs
 - **llama-stack** — Llama Stack API (chat, vector stores); default inference via MaaS / `external-model`
 - **llm-service** — Optional in-cluster model serving (disabled by default)
-- **general-simulation** — Optional subchart (own Postgres + Neo4j + API + ingestion); see below
+- **general-simulation** — Optional subchart (Postgres + Neo4j + API + ingestion); see below
 - **backend** — Flask API
 - **frontend** — React dashboard (nginx)
 - **ingest** — Optional post-install Job (`ingest.enabled`)
@@ -62,7 +62,7 @@ oc create secret generic huggingface-secret \
 
 ## General Simulation subchart
 
-Enabled by default via `general-simulation.enabled`. Gen-sim brings its **own** Postgres and Neo4j into the **same** namespace as this release. The agent keeps `pgvector` for its own RAG.
+Enabled by default via `general-simulation.enabled`. Gen-sim brings Postgres and Neo4j into the **same** namespace. With `pgvector.enabled: false` (default), the agent and Llama Stack reuse that Postgres via an umbrella `Secret/pgvector` bridge (`host: postgres`, db/user `sim`). Set `pgvector.enabled: true` only for agent-only installs without gen-sim.
 
 **Gen-sim does not use MaaS.** It calls OpenAI (`api.llm.backend: openai`) with `apiKey` from `helm/secrets.yaml`. Override `baseUrl` if you want a different OpenAI-compatible endpoint.
 
@@ -92,14 +92,24 @@ make seed-opensky-live GEN_SIM_NAMESPACE=supply-chain-dashboard
 
 Requires a local [general-simulation](https://github.com/robertsandoval/general-simulation) checkout (default `../general-simulation`) and `oc` login.
 
-To use a **standalone** gen-sim install in another project instead:
+To use a **standalone** gen-sim install in another project instead (and restore the standalone pgvector chart for agent RAG):
 
 ```yaml
 general-simulation:
   enabled: false
+pgvector:
+  enabled: true
+  secret:
+    user: postgres
+    password: password
+    dbname: blueprint
+    host: pgvector
 backend:
   env:
     GENERAL_SIMULATION_BASE_URL: "http://general-sim-api.general-simulation.svc:8000"
+    PG_HOST: pgvector
+    PG_USER: postgres
+    PG_DB: blueprint
 ```
 
 ## Install

--- a/helm/multi-llm-values.yaml
+++ b/helm/multi-llm-values.yaml
@@ -8,16 +8,16 @@ global:
       id: gpt-4o-mini
 
 pgvector:
-  enabled: true
+  enabled: false
   secret:
     create: true
-    user: postgres
+    user: sim
     # Demo default — override via helm/secrets.yaml if needed.
     # Do not set password to "" (blank overlay wipes the Secret).
-    # Changing after first install requires deleting PVC pg-data-pgvector-0.
+    # Must match general-simulation.postgres.postgres.password.
     password: password
-    dbname: blueprint
-    host: pgvector
+    dbname: sim
+    host: postgres
     port: "5432"
 
 llama-stack:
@@ -70,8 +70,7 @@ backend:
     enabled: true
     host: ""
     timeout: 5m
-  # Name of the Secret created by the pgvector sub-chart that holds the
-  # database password under the key "password".
+  # Secret/pgvector (bridge or subchart) — key "password".
   pgvectorSecretName: pgvector
   env:
     LLAMA_STACK_URL: http://llamastack.supply-chain-dashboard.svc.cluster.local:8321
@@ -79,13 +78,12 @@ backend:
     # OpenAI client timeout (seconds) for chat and vector-store API calls.
     LLAMA_STACK_TIMEOUT_SECONDS: "300"
     EMBED_MODEL: all-MiniLM-L6-v2
-    # PG_ prefix avoids collision with the Kubernetes service-discovery
-    # variable PGVECTOR_PORT=tcp://ip:port that is auto-injected for the
-    # pgvector Service, which would corrupt SQLAlchemy URL parsing.
-    PG_HOST: pgvector
+    # PG_ prefix avoids collision with a Kubernetes service-discovery
+    # PGVECTOR_PORT=tcp://… var if a Service named pgvector exists.
+    PG_HOST: postgres
     PG_PORT: "5432"
-    PG_USER: postgres
-    PG_DB: blueprint
+    PG_USER: sim
+    PG_DB: sim
 
 ingest:
   # Set to true to run the knowledge-base ingestion Job on every

--- a/helm/secrets.example.yaml
+++ b/helm/secrets.example.yaml
@@ -5,14 +5,17 @@
 #   cp helm/secrets.example.yaml helm/secrets.yaml
 #   EDIT helm/secrets.yaml with your secrets
 #
-# PGVector password notes:
-#   - Omit pgvector.secret.password to keep the demo default from values.yaml.
+# Shared Postgres password notes (default: gen-sim Postgres + Secret/pgvector bridge):
+#   - Keep pgvector.secret.password in sync with general-simulation.*.postgres.password.
+#   - Omit password keys to keep the demo defaults from values.yaml.
 #   - Never set password to "" — an empty overlay blanks the Secret and breaks
-#     LlamaStack → PGVector auth.
+#     LlamaStack → Postgres auth.
 #   - Never replace pgvector.secret with an empty/comment-only map (YAML null);
 #     that wipes user/host/dbname as well.
-#   - Changing the password after first install requires deleting PVC
-#     pg-data-pgvector-0 (Postgres applies POSTGRES_PASSWORD only on init).
+#   - Changing the password after first install requires deleting the gen-sim
+#     Postgres PVC (POSTGRES_PASSWORD applies only on init).
+#   - Agent-only installs (general-simulation.enabled: false): set
+#     pgvector.enabled: true and use the standalone pgvector PVC instead.
 
 # Unused while llm-service.enabled is false (default). Required only when you
 # re-enable a local gated model under llm-service.
@@ -27,10 +30,23 @@ global:
     external-model:
       apiToken: "sk-..."
 
-# Optional PGVector override example (uncomment the block AND set password):
+# Optional shared-Postgres override (uncomment AND set the same password everywhere):
 # pgvector:
 #   secret:
 #     password: "change-me"
+# general-simulation:
+#   postgres:
+#     postgres:
+#       password: "change-me"
+#   api:
+#     postgres:
+#       password: "change-me"
+#   bootstrap:
+#     postgres:
+#       password: "change-me"
+#   ingestion:
+#     postgres:
+#       password: "change-me"
 
 # Required when general-simulation.enabled is true (see values.yaml).
 # Also create Secret neo4j-auth in the release namespace before install:
@@ -41,24 +57,15 @@ global:
 # Gen-sim uses OpenAI (not MaaS). Set apiKey under api.llm and ingestion.llm.
 #
 # general-simulation:
-#   postgres:
-#     postgres:
-#       password: "change-me"
 #   api:
-#     postgres:
-#       password: "change-me"
 #     neo4j:
 #       password: "change-me"
 #     llm:
 #       apiKey: "sk-..."
 #   bootstrap:
-#     postgres:
-#       password: "change-me"
 #     neo4j:
 #       password: "change-me"
 #   ingestion:
-#     postgres:
-#       password: "change-me"
 #     neo4j:
 #       password: "change-me"
 #     llm:

--- a/helm/templates/ingest-job.yaml
+++ b/helm/templates/ingest-job.yaml
@@ -16,7 +16,7 @@ metadata:
     helm.sh/hook-weight: "10"
 spec:
   backoffLimit: 2
-  # 10-minute hard deadline — covers slow cold-starts of pgvector / llamastack.
+  # 10-minute hard deadline — covers slow cold-starts of Postgres / llamastack.
   activeDeadlineSeconds: 600
   template:
     metadata:
@@ -36,8 +36,8 @@ spec:
       # ── Init containers: block until dependencies are accepting traffic ──
       initContainers:
 
-        # 1. Wait for PGVector to accept TCP connections on port 5432.
-        - name: wait-for-pgvector
+        # 1. Wait for shared Postgres to accept TCP connections on port 5432.
+        - name: wait-for-postgres
           image: busybox:1.36
           securityContext:
             allowPrivilegeEscalation: false
@@ -47,12 +47,12 @@ spec:
             - sh
             - -c
             - |
-              echo "Waiting for pgvector at {{ .Values.backend.env.PG_HOST }}:{{ .Values.backend.env.PG_PORT }} ..."
+              echo "Waiting for Postgres at {{ .Values.backend.env.PG_HOST }}:{{ .Values.backend.env.PG_PORT }} ..."
               until nc -z {{ .Values.backend.env.PG_HOST }} {{ .Values.backend.env.PG_PORT }}; do
-                echo "  pgvector not ready — retrying in 5s"
+                echo "  Postgres not ready — retrying in 5s"
                 sleep 5
               done
-              echo "pgvector is up."
+              echo "Postgres is up."
 
         # 2. Wait for Llama Stack to return HTTP 200 on /v1/models.
         - name: wait-for-llamastack

--- a/helm/templates/network-policy-egress.yaml
+++ b/helm/templates/network-policy-egress.yaml
@@ -31,7 +31,7 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
-    # Same-namespace cluster services (pgvector, llamastack, general-sim).
+    # Same-namespace cluster services (postgres, llamastack, general-sim).
     - to:
         - namespaceSelector:
             matchLabels:

--- a/helm/templates/pgvector-bridge-secret.yaml
+++ b/helm/templates/pgvector-bridge-secret.yaml
@@ -1,0 +1,24 @@
+{{- /*
+  Llama Stack hardcodes Secret name "pgvector" (keys: user, password, host,
+  port, dbname). When the pgvector subchart is disabled, this umbrella Secret
+  keeps that contract while pointing at gen-sim's Postgres Service (AGE +
+  vector + PostGIS). Password must match general-simulation.postgres.postgres.password.
+*/ -}}
+{{- if and (not .Values.pgvector.enabled) .Values.pgvector.secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.backend.pgvectorSecretName | default "pgvector" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: supply-chain-agent
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: shared-postgres
+type: Opaque
+data:
+  user: {{ required "pgvector.secret.user is required when pgvector.enabled is false" .Values.pgvector.secret.user | b64enc | quote }}
+  password: {{ required "pgvector.secret.password is required when pgvector.enabled is false (must match general-simulation Postgres password)" .Values.pgvector.secret.password | b64enc | quote }}
+  host: {{ required "pgvector.secret.host is required when pgvector.enabled is false" .Values.pgvector.secret.host | b64enc | quote }}
+  port: {{ .Values.pgvector.secret.port | default "5432" | toString | b64enc | quote }}
+  dbname: {{ required "pgvector.secret.dbname is required when pgvector.enabled is false" .Values.pgvector.secret.dbname | b64enc | quote }}
+{{- end }}

--- a/helm/tests/backend_deployment_test.yaml
+++ b/helm/tests/backend_deployment_test.yaml
@@ -11,10 +11,10 @@ tests:
       backend.pgvectorSecretName: pgvector
       backend.env.LLAMA_STACK_URL: "http://llamastack.example:8321"
       backend.env.EMBED_MODEL: "all-MiniLM-L6-v2"
-      backend.env.PG_HOST: pgvector
+      backend.env.PG_HOST: postgres
       backend.env.PG_PORT: "5432"
-      backend.env.PG_USER: postgres
-      backend.env.PG_DB: blueprint
+      backend.env.PG_USER: sim
+      backend.env.PG_DB: sim
       backend.env.GENERAL_SIMULATION_BASE_URL: "http://general-sim-api:8000"
       global.models.llama-3-2-3b-instruct.enabled: true
       global.models.external-model.id: "gpt-4o-mini"
@@ -53,7 +53,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: PG_HOST
-            value: pgvector
+            value: postgres
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -85,10 +85,10 @@ tests:
       backend.enabled: true
       backend.pgvectorSecretName: pgvector
       backend.env.LLAMA_STACK_URL: "http://llamastack.example:8321"
-      backend.env.PG_HOST: pgvector
+      backend.env.PG_HOST: postgres
       backend.env.PG_PORT: "5432"
-      backend.env.PG_USER: postgres
-      backend.env.PG_DB: blueprint
+      backend.env.PG_USER: sim
+      backend.env.PG_DB: sim
       global.models.llama-3-2-3b-instruct.enabled: false
       global.models.external-model.id: "Qwen3.6-35B-A3B"
     asserts:

--- a/helm/tests/ingest_job_test.yaml
+++ b/helm/tests/ingest_job_test.yaml
@@ -13,10 +13,10 @@ tests:
       backend.pgvectorSecretName: pgvector
       backend.env.LLAMA_STACK_URL: "http://llamastack:8321"
       backend.env.EMBED_MODEL: "all-MiniLM-L6-v2"
-      backend.env.PG_HOST: pgvector
+      backend.env.PG_HOST: postgres
       backend.env.PG_PORT: "5432"
-      backend.env.PG_USER: postgres
-      backend.env.PG_DB: blueprint
+      backend.env.PG_USER: sim
+      backend.env.PG_DB: sim
     asserts:
       - isKind:
           of: Job
@@ -55,10 +55,10 @@ tests:
       ingest.strategy: llamastack
       backend.env.LLAMA_STACK_URL: "http://llamastack:8321"
       backend.env.EMBED_MODEL: "all-MiniLM-L6-v2"
-      backend.env.PG_HOST: pgvector
+      backend.env.PG_HOST: postgres
       backend.env.PG_PORT: "5432"
-      backend.env.PG_USER: postgres
-      backend.env.PG_DB: blueprint
+      backend.env.PG_USER: sim
+      backend.env.PG_DB: sim
     asserts:
       - notExists:
           path: metadata.annotations["helm.sh/hook-delete-policy"]
@@ -70,10 +70,10 @@ tests:
       ingest.hookDeletePolicy: before-hook-creation
       backend.env.LLAMA_STACK_URL: "http://llamastack:8321"
       backend.env.EMBED_MODEL: "all-MiniLM-L6-v2"
-      backend.env.PG_HOST: pgvector
+      backend.env.PG_HOST: postgres
       backend.env.PG_PORT: "5432"
-      backend.env.PG_USER: postgres
-      backend.env.PG_DB: blueprint
+      backend.env.PG_USER: sim
+      backend.env.PG_DB: sim
     asserts:
       - equal:
           path: metadata.annotations["helm.sh/hook-delete-policy"]

--- a/helm/tests/pgvector_bridge_secret_test.yaml
+++ b/helm/tests/pgvector_bridge_secret_test.yaml
@@ -1,0 +1,52 @@
+suite: pgvector bridge secret
+templates:
+  - templates/pgvector-bridge-secret.yaml
+release:
+  name: supply-chain-dashboard
+  namespace: supply-chain-dashboard
+tests:
+  - it: renders Llama Stack compatible secret pointing at gen-sim postgres
+    set:
+      pgvector.enabled: false
+      pgvector.secret.create: true
+      pgvector.secret.user: sim
+      pgvector.secret.password: demo-password
+      pgvector.secret.host: postgres
+      pgvector.secret.port: "5432"
+      pgvector.secret.dbname: sim
+      backend.pgvectorSecretName: pgvector
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: pgvector
+      - equal:
+          path: data.user
+          value: c2lt
+      - equal:
+          path: data.host
+          value: cG9zdGdyZXM=
+      - equal:
+          path: data.dbname
+          value: c2lt
+      - equal:
+          path: data.port
+          value: NTQzMg==
+
+  - it: does not render when pgvector subchart is enabled
+    set:
+      pgvector.enabled: true
+      pgvector.secret.create: true
+      pgvector.secret.password: unused
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render when secret.create is false
+    set:
+      pgvector.enabled: false
+      pgvector.secret.create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm/tests/test_pgvector_secret.py
+++ b/helm/tests/test_pgvector_secret.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
-"""Guardrails for the pgvector Helm Secret password.
+"""Guardrails for the shared Postgres Helm Secret password (Secret/pgvector).
 
-The secrets overlay must never blank ``pgvector.secret.password``. An empty
-string replaces the chart default and produces a Secret with no password,
-which makes LlamaStack crash with::
+With ``pgvector.enabled: false`` (default), the umbrella bridge template
+creates Secret/pgvector for Llama Stack. The secrets overlay must never blank
+``pgvector.secret.password``. An empty string replaces the chart default and
+produces a Secret with no password, which makes LlamaStack crash with::
 
-    FATAL: password authentication failed for user "postgres"
+    FATAL: password authentication failed for user "sim"
 
-Postgres only applies ``POSTGRES_PASSWORD`` on first init, so changing the
-password after install also requires deleting PVC ``pg-data-pgvector-0``.
+Keep ``pgvector.secret.password`` in sync with
+``general-simulation.postgres.postgres.password``. Postgres only applies
+``POSTGRES_PASSWORD`` on first init, so changing the password after install
+also requires deleting the gen-sim Postgres PVC.
 """
 
 from __future__ import annotations
@@ -53,12 +56,10 @@ def _helm_template(*value_files: Path) -> str:
         str(HELM_CHART),
         "--namespace",
         "supply-chain-dashboard",
-        # This guardrail only cares about the pgvector Secret. general-simulation
+        # This guardrail only cares about Secret/pgvector. general-simulation
         # is an unrelated, independently-toggled subchart with its own required
-        # Postgres/Neo4j secrets (including a live-cluster `lookup` for a
-        # pre-created neo4j-auth Secret) that `helm template` can never satisfy
-        # without a real cluster — disable it so this check stays scoped to
-        # pgvector regardless of general-simulation's wiring.
+        # Neo4j lookup that `helm template` can never satisfy without a real
+        # cluster — disable it so this check stays scoped to the bridge Secret.
         "--set",
         "general-simulation.enabled=false",
     ]
@@ -127,7 +128,7 @@ def test_helm_render_keeps_non_empty_password_with_secrets_example() -> None:
     password = _rendered_pgvector_password(manifest)
     assert password, (
         "Rendered Secret/pgvector.password is empty when applying "
-        "secrets.example.yaml over values.yaml — LlamaStack cannot auth to PGVector"
+        "secrets.example.yaml over values.yaml — LlamaStack cannot auth to Postgres"
     )
 
 
@@ -137,12 +138,24 @@ def test_helm_render_values_alone_has_password() -> None:
     assert password, "Rendered Secret/pgvector.password is empty for values.yaml alone"
 
 
+def test_bridge_secret_points_at_shared_postgres() -> None:
+    """Default shared-DB mode must target Service postgres / db sim."""
+    data = _load_yaml(VALUES)
+    pg = data.get("pgvector") or {}
+    assert pg.get("enabled") is False, "default install should disable pgvector STS"
+    secret = pg.get("secret") or {}
+    assert secret.get("host") == "postgres"
+    assert secret.get("user") == "sim"
+    assert secret.get("dbname") == "sim"
+
+
 def main() -> int:
     tests = [
         test_secrets_example_does_not_blank_password,
         test_committed_values_define_non_empty_password,
         test_helm_render_values_alone_has_password,
         test_helm_render_keeps_non_empty_password_with_secrets_example,
+        test_bridge_secret_points_at_shared_postgres,
     ]
     failed = 0
     for test in tests:

--- a/helm/values-kind.yaml
+++ b/helm/values-kind.yaml
@@ -8,8 +8,11 @@
 #   llama-stack, llm-service, umbrella ingest Job, gen-sim OpenSky CronJob, vLLM.
 # OpenShift Routes disabled (no router on Kind).
 
+# Shared DB: bridge Secret/pgvector → Service postgres (password must match below).
 pgvector:
-  enabled: true
+  enabled: false
+  secret:
+    password: kind-demo-password
 
 llama-stack:
   enabled: false
@@ -25,6 +28,9 @@ backend:
   env:
     # Unused while llama-stack is off; backend probes /healthz (liveness-only).
     LLAMA_STACK_URL: http://llamastack:8321
+    PG_HOST: postgres
+    PG_USER: sim
+    PG_DB: sim
 
 frontend:
   route:
@@ -39,8 +45,8 @@ ingest:
 
 # Demo-only credentials so general-simulation's Postgres/Neo4j secret templates
 # render in the ephemeral Kind namespace (see helm/secrets.example.yaml for the
-# real-deployment equivalent, kept out of values.yaml on purpose). The matching
-# neo4j-auth Secret is pre-created by .github/actions/kind before `helm install`.
+# real-deployment equivalent). The matching neo4j-auth Secret is pre-created by
+# .github/actions/kind before `helm install`.
 #
 # Published gen-sim defaults pin Neo4j to gp3-csi + 2CPU/4Gi (OpenShift/AWS).
 # Kind has neither that StorageClass nor the headroom — without these overrides

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -12,19 +12,26 @@ global:
       url: https://litemaas.rhoai.rh-aiservices-bu.com/v1
       apiToken: "" # Set in helm/secrets.yaml
 
+# Shared Postgres: when general-simulation is enabled (default), disable the
+# standalone pgvector StatefulSet and reuse gen-sim's Postgres (AGE + vector +
+# PostGIS). The umbrella template creates Secret/pgvector for Llama Stack.
+# For agent-only installs (general-simulation.enabled: false), set
+# pgvector.enabled: true so the subchart deploys its own DB.
 pgvector:
-  enabled: true
+  enabled: false
   secret:
     create: true
-    user: postgres
+    # Must match general-simulation.postgres.postgres.username / database /
+    # password (Service hostname is "postgres").
+    user: sim
     # ⚠️ Demo default only. Override via helm/secrets.yaml if needed.
     # Do NOT set password to "" — an empty overlay blanks the Secret and
-    # breaks LlamaStack auth to PGVector.
-    # Changing the password after first install requires deleting PVC
-    # pg-data-pgvector-0 (Postgres applies POSTGRES_PASSWORD only on init).
+    # breaks LlamaStack auth to Postgres.
+    # Changing the password after first install requires deleting the gen-sim
+    # Postgres PVC (POSTGRES_PASSWORD applies only on init).
     password: password
-    dbname: blueprint
-    host: pgvector
+    dbname: sim
+    host: postgres
     port: "5432"
 
 llama-stack:
@@ -75,11 +82,21 @@ general-simulation:
       backend: openai
       baseUrl: https://api.openai.com/v1
       # apiKey via helm/secrets.yaml
+    postgres:
+      user: sim
+      password: password
+      database: sim
+      host: postgres
   bootstrap:
     image: quay.io/rh-ai-quickstart/general-simulation-api:latest
     waitFor:
       enabled: true
       timeoutSeconds: 300
+    postgres:
+      user: sim
+      password: password
+      database: sim
+      host: postgres
   # Live OpenSky CronJob (opensky-network.org). Keep disabled on AWS/hyperscaler
   # clusters: OpenSky drops those source IPs at TCP (documented; they refuse AI
   # dashboard allowlists). Cluster NetworkPolicy / EgressFirewall cannot fix it.
@@ -92,9 +109,11 @@ general-simulation:
       backend: openai
       baseUrl: https://api.openai.com/v1
       # apiKey via helm/secrets.yaml
-  # Passwords via helm/secrets.yaml (see secrets.example.yaml) — do not commit.
-  # postgres.postgres.password, api/bootstrap/ingestion postgres+neo4j passwords,
-  # and Neo4j Secret neo4j-auth must be provided before install.
+    postgres:
+      user: sim
+      password: password
+      database: sim
+      host: postgres
 
 imagePullSecrets: []
 
@@ -124,8 +143,7 @@ backend:
     enabled: true
     host: ""
     timeout: 5m
-  # Name of the Secret created by the pgvector sub-chart that holds the
-  # database password under the key "password".
+  # Secret/pgvector (bridge template or pgvector subchart) — key "password".
   pgvectorSecretName: pgvector
   env:
     LLAMA_STACK_URL: http://llamastack.supply-chain-dashboard.svc.cluster.local:8321
@@ -134,15 +152,15 @@ backend:
     # OpenAI client timeout (seconds) for chat and vector-store API calls.
     LLAMA_STACK_TIMEOUT_SECONDS: "300"
     EMBED_MODEL: all-MiniLM-L6-v2
-    # PG_ prefix avoids collision with the Kubernetes service-discovery
-    # variable PGVECTOR_PORT=tcp://ip:port that is auto-injected for the
-    # pgvector Service, which would corrupt SQLAlchemy URL parsing.
+    # PG_ prefix avoids collision with a Kubernetes service-discovery
+    # PGVECTOR_PORT=tcp://… var if a Service named pgvector exists.
     # Same-namespace short name when general-simulation is a subchart.
     GENERAL_SIMULATION_BASE_URL: "http://general-sim-api:8000"
-    PG_HOST: pgvector
+    # Shared gen-sim Postgres (when pgvector.enabled is false).
+    PG_HOST: postgres
     PG_PORT: "5432"
-    PG_USER: postgres
-    PG_DB: blueprint
+    PG_USER: sim
+    PG_DB: sim
     # News ticker RSS feeds (HTTPS egress required to reach defaults).
     # Leave empty for BBC World/Business + Guardian World.
     # Override for air-gapped clusters: "Internal|https://intranet.example/rss"


### PR DESCRIPTION
## Description

- Right now both ai-supply-chain-agent and general-simulation repo asking for r 
- AI Supply Chain: 
- General Simulation: Use this PG instance
- 
<img width="733" height="520" alt="image" src="https://github.com/user-attachments/assets/0ef49e74-2388-49ef-b7eb-7ec77c6fd612" />

---

## Related Issue(s)

Closes # (if applicable):

---

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe):

---

## Checklist

- [x] I have tested my code changes
- [ ] I have updated relevant documentation as needed
- [x] The code follows the project's coding standards and style
- [ ] All existing and new tests pass

---

## Additional Context

Add any other context or screenshots about the PR here.